### PR TITLE
Fix ignore_double_indices

### DIFF
--- a/conll_transform.py
+++ b/conll_transform.py
@@ -85,7 +85,7 @@ def read_file(fpath, sep=None, ignore_double_indices=False,
                 sentences.append([])
             new_sentence = False
             split = line[:-1].split(sep)
-            if isinstance(ignore_double_indices, int) and \
+            if type(ignore_double_indices) is int and \
                     ignore_double_indices >= 0 and "-" in split[ignore_double_indices]:
                 continue
             sentences[-1].append(split)


### PR DESCRIPTION
 `ignore_double_indices` counterintuitively ignores double indices when set to False. This is because `isinstance(False, int)` and `False >= 0` evaluate as True. Changing to `type(False) is int` to fix this behavior.